### PR TITLE
[Use cases] Add a use case for normal access pattern.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -112,8 +112,8 @@ she downloads the photos and posts them to the NAS device.
 ## UC-07: Secure offline communication for home automation ## {#uc-07}
 
 A user wants to set up a new home device (e.g., a Wi-Fi access point/router,
-home automation gateway) in his/her home using via its web interface.
-User typically opens a given URL (e.g., https://home-router.local, or https://192.168.1.1)
+home automation gateway) in his/her home via its web interface.
+User typically opens a given URL for the device (e.g., https://home-router.local, or https://192.168.1.1)
 in a laptop or smart phone’s web browser. Since the new device does not have
 a valid web PKI certificate, the web browser displays a warning like 
 “The connection is not secure” but provides an option to ask the user to

--- a/index.bs
+++ b/index.bs
@@ -111,12 +111,26 @@ she downloads the photos and posts them to the NAS device.
 
 ## UC-07: Secure offline communication for home automation ## {#uc-07}
 
-A user sets up a home automation gateway is under normal circumstances using
-HTTPS to securely accept commands via a remote server. In some cases the
-gateways internet connection is interrupted but local communication between a
-wall mounted control surface, app, or similar should stil be given. This becomes
-very important when we consider that devices that can be controlled this way
-include door locks and security cameras.
+A user wants to set up a new home device (e.g., a Wi-Fi access point/router,
+home automation gateway) in his/her home using the device web interface.
+User typically connects the device with a laptop or a smartphone and then
+launches a given URL (e.g., https://home-router.local, or https://192.168.1.1)
+on the laptop or smart phone’s web browser. Since the new device does not have
+a valid web PKI certificate, the web browser displays a warning that typically
+says, “The connection is not secure” but provides an option to the user to
+approve the access or add the URL as an exception to the access list.
+Once user takes the action, the web browser treats the device as a trusted one
+and does not display the warning in subsequent attempts. Additionally, if the
+home device supports functionality such as, SSO (Single Sign On) the user can
+use an identity (ID) provider's account (e.g., Google, Facebook, and so on)
+to sign in the device’s web interface and provide the needed trust.
+
+Similar secure access is required when a home gateway, which is typically
+controlling other home devices (e.g., door locks, security cameras), uses HTTPS
+for securely accepting commands via a remote server gets temporarily disconnected
+from the Internet. In such scenarios, a local HTTPS communication from user’s
+local device (e.g., smart phone or a control device) is essential to control
+and operate the home device.
 
 ## UC-08: Companion Device for Broadcast Interactive Service ## {#uc-08}
 

--- a/index.bs
+++ b/index.bs
@@ -128,7 +128,7 @@ to sign in the device’s web interface and provide the needed trust.
 Similar secure access is required when a home gateway, which is typically
 controlling other home devices (e.g., door locks, security cameras), uses HTTPS
 for securely accepting commands via a remote server gets temporarily disconnected
-from the Internet. In such scenarios, a local HTTPS communication from user’s
+from the internet. In such scenarios, a local HTTPS communication from user’s
 local device (e.g., smart phone or a control device) is essential to control
 and operate the home device.
 

--- a/index.bs
+++ b/index.bs
@@ -112,25 +112,26 @@ she downloads the photos and posts them to the NAS device.
 ## UC-07: Secure offline communication for home automation ## {#uc-07}
 
 A user wants to set up a new home device (e.g., a Wi-Fi access point/router,
-home automation gateway) in his/her home using the device web interface.
-User typically connects the device with a laptop or a smartphone and then
-launches a given URL (e.g., https://home-router.local, or https://192.168.1.1)
-on the laptop or smart phone’s web browser. Since the new device does not have
-a valid web PKI certificate, the web browser displays a warning that typically
-says, “The connection is not secure” but provides an option to the user to
-approve the access or add the URL as an exception to the access list.
+home automation gateway) in his/her home using via its web interface.
+User typically opens a given URL (e.g., https://home-router.local, or https://192.168.1.1)
+in a laptop or smart phone’s web browser. Since the new device does not have
+a valid web PKI certificate, the web browser displays a warning like 
+“The connection is not secure” but provides an option to ask the user to
+approve the access or add the URL as an exception to the whitelist.
 Once user takes the action, the web browser treats the device as a trusted one
 and does not display the warning in subsequent attempts. Additionally, if the
-home device supports functionality such as, SSO (Single Sign On) the user can
+home device supports functionality such as, SSO (Single Sign-On) the user can
 use an identity (ID) provider's account (e.g., Google, Facebook, and so on)
 to sign in the device’s web interface and provide the needed trust.
 
 Similar secure access is required when a home gateway, which is typically
-controlling other home devices (e.g., door locks, security cameras), uses HTTPS
-for securely accepting commands via a remote server gets temporarily disconnected
-from the internet. In such scenarios, a local HTTPS communication from user’s
+controlling other home devices (e.g., door locks, security cameras), 
+uses HTTPS for securely accepting commands via a remote server. 
+However, when a home gateway happens to get temporarily disconnected
+from the internet, those home devices become inaccessible. 
+In such scenarios, a local HTTPS communication from user’s
 local device (e.g., smart phone or a control device) is essential to control
-and operate the home device.
+and operate the home devices directly through HTTPS connections over the local network.
 
 ## UC-08: Companion Device for Broadcast Interactive Service ## {#uc-08}
 


### PR DESCRIPTION
Thanks @tomoyukilabs for drafting the CG report.

As I mentioned in [my proposal](#https://github.com/dajiaji/proposals/blob/abstract_proposal/draft_proposal_supporting_local_https_communication.md), I think we can categorize two device access patterns principle for local HTTPS as follows. 

> - Normal access pattern: the device has web contents and a user types the address of the device (e.g., ‘https://device.local’) on the browser directly and receives the contents.
> - Cross-origin access pattern: the device has API endpoints and a web frontend loaded on a browser from the internet (hereafter, simply called ‘web service’) accesses the APIs with a browser API (e.g., fetch API) and receives the contents.

Although [The current CG report draft](#https://httpslocal.github.io/usecases/) includes many use cases for the cross-origin access pattern,
there is no use case for the normal access pattern.
So I'd like to add a use case for the normal access pattern by modifying UC-07.
It is because the UC-07 treats home gateways which can be accessed by way of the normal access pattern and, in addition, I don't want to increase the number of use cases any more.

Could you check the PR?